### PR TITLE
Fix missing close curly bracket

### DIFF
--- a/readme.md
+++ b/readme.md
@@ -213,7 +213,7 @@ const sum = list => {
       ? acc
       : go(acc + first(xs), rest(xs));
   return go(0, list) 
-
+}
 ```
 
 **[⬆ back to top](#quick-links)**

--- a/readme_kr.md
+++ b/readme_kr.md
@@ -213,7 +213,7 @@ const sum = list => {
       ? acc
       : go(acc + first(xs), rest(xs));
   return go(0, list) 
-
+}
 ```
 
 **[⬆ back to top](#quick-links)**


### PR DESCRIPTION
It seems like we're missing a close curly bracket (`}`), which encloses the body of the [Tail recursive sum](https://github.com/you-dont-need/You-Dont-Need-Loops/tree/d9e9b6bea5ae677240ce0655d4b2c31e47f9e9d0#tail-recursive-sum) function.

```js
const sum = list => {
  const go = (acc, xs) =>
    xs.length === 0
      ? acc
      : go(acc + first(xs), rest(xs));
  return go(0, list) 
}  // <- this one is missing
```

English ver. and Korean ver. are both fixed 😄 
Thank you for making such great repo 🚀 